### PR TITLE
Sync translation font size with sidebar option

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -152,7 +152,7 @@ a {
 }
 
 .translation {
-  font-size: 14px;
+  font-size: var(--translation-size, 14px);
   color: var(--muted);
   margin-top: 6px;
 }

--- a/apps/web/app/s/[surah]/reader-client.tsx
+++ b/apps/web/app/s/[surah]/reader-client.tsx
@@ -367,6 +367,7 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
     }, [verses, isSurahOpen, isSidebarOpen])
 
     const arabicSizeVar = font === 'sm' ? '20px' : font === 'lg' ? '28px' : '24px'
+    const translationSizeVar = font === 'sm' ? '12px' : font === 'lg' ? '16px' : '14px'
     const selectedTranslations = translations.filter((t) => enabledTranslations.includes(t.id))
 
     function pad3(n: number) {
@@ -713,7 +714,10 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
                             ))}
                         </div>
                     ) : (
-                        <div ref={listRef} style={{ '--arabic-size': arabicSizeVar } as React.CSSProperties}>
+                        <div
+                            ref={listRef}
+                            style={{ '--arabic-size': arabicSizeVar, '--translation-size': translationSizeVar } as React.CSSProperties}
+                        >
                             {verses.map((v) => (
                                 <article
                                     key={v.ayah}


### PR DESCRIPTION
## Summary
- link translation text size to existing font option
- expose translation size variable in CSS for unified control

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration file)*
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a8a84dbd8083329238231385dcef82