### PR TITLE
style: apply accent color to sidebar checkboxes

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -236,6 +236,10 @@ a {
   transform: translateX(0);
 }
 
+.sidebar input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
 .section {
   margin-bottom: 16px;
 }


### PR DESCRIPTION
## Summary
- ensure sidebar checkboxes use application's accent color

## Testing
- `pnpm --filter web lint` *(fails: ESLint couldn't find config)*
- `pnpm --filter web typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8aaa73d6c8332a7a869904d51f112