### PR TITLE
Add client-side Ollama word root lookup

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -266,3 +266,13 @@ a {
   height: 24px;
   background: rgba(255, 255, 255, 0.08);
 }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}

--- a/apps/web/app/s/[surah]/Sidebar.tsx
+++ b/apps/web/app/s/[surah]/Sidebar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Route } from 'next'
 import {
@@ -21,6 +21,7 @@ import {
   FolderOutput,
   FolderInput,
   Github,
+  Cpu,
   Sun,
   Moon,
   MapPin,
@@ -30,6 +31,7 @@ import {
 import type { TranslationMeta } from '@openquranreader/types'
 import type { BookmarksSet, NotesMap, VerseKey } from './types'
 import { encodeSharePayload } from '../../../lib/share'
+import { OllamaClient } from '../../../lib/ollama'
 
 interface SidebarProps {
   isOpen: boolean
@@ -48,6 +50,12 @@ interface SidebarProps {
   notes: NotesMap
   setBookmarks: React.Dispatch<React.SetStateAction<BookmarksSet>>
   setNotes: React.Dispatch<React.SetStateAction<NotesMap>>
+  ollamaEnabled: boolean
+  setOllamaEnabled: React.Dispatch<React.SetStateAction<boolean>>
+  ollamaEndpoint: string
+  setOllamaEndpoint: React.Dispatch<React.SetStateAction<string>>
+  ollamaModel: string
+  setOllamaModel: React.Dispatch<React.SetStateAction<string>>
   setActiveAyah: (a: number) => void
   setOpenNoteAyah: (a: number) => void
   hydrated: boolean
@@ -70,6 +78,12 @@ export default function Sidebar({
   notes,
   setBookmarks,
   setNotes,
+  ollamaEnabled,
+  setOllamaEnabled,
+  ollamaEndpoint,
+  setOllamaEndpoint,
+  ollamaModel,
+  setOllamaModel,
   setActiveAyah,
   setOpenNoteAyah,
   hydrated,
@@ -83,6 +97,8 @@ export default function Sidebar({
   const [isExportOpen, setIsExportOpen] = useState(false)
   const [isImportOpen, setIsImportOpen] = useState(false)
   const [isClearOpen, setIsClearOpen] = useState(false)
+  const [isOllamaOpen, setIsOllamaOpen] = useState(false)
+  const [models, setModels] = useState<string[]>([])
   const [clearNav, setClearNav] = useState(false)
   const [clearBm, setClearBm] = useState(false)
   const [clearNt, setClearNt] = useState(false)
@@ -99,6 +115,15 @@ export default function Sidebar({
   const reciterDisplayName = reciterOptions.find((r) => r.id === reciter)?.name || 'Choose'
   const reciterDisplayShort =
     reciterDisplayName === 'Choose' ? reciterDisplayName : `${reciterDisplayName.slice(0, 7)}...`
+
+  useEffect(() => {
+    if (!ollamaEnabled || !isOllamaOpen) return
+    const client = new OllamaClient(ollamaEndpoint)
+    void client.listModels().then((ms) => {
+      setModels(ms)
+      if (ms.length && (!ollamaModel || !ms.includes(ollamaModel))) setOllamaModel(ms[0])
+    })
+  }, [ollamaEnabled, isOllamaOpen, ollamaEndpoint])
 
   function clearAllNavigations() {
     try {
@@ -599,6 +624,59 @@ export default function Sidebar({
                 <button type="button" className="button" disabled={!clearNav && !clearBm && !clearNt && !clearSt} onClick={handleClearSelected}>
                   Clear
                 </button>
+              </div>
+            ) : null}
+        </div>
+        </div>
+
+        <div className="section">
+          <div role="region" aria-label="Ollama">
+            <button
+              type="button"
+              className="button"
+              aria-expanded={isOllamaOpen}
+              aria-controls="accordion-ollama"
+              onClick={() => setIsOllamaOpen((o) => !o)}
+              style={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+            >
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                <Cpu className="icon" strokeWidth={2} aria-hidden />
+                <span>Ollama</span>
+              </span>
+              <ChevronDown className="icon" strokeWidth={2} aria-hidden style={{ transform: isOllamaOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }} />
+            </button>
+            {isOllamaOpen ? (
+              <div id="accordion-ollama" style={{ marginTop: 8, display: 'grid', gap: 8 }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <input
+                    type="checkbox"
+                    checked={ollamaEnabled}
+                    onChange={(e) => setOllamaEnabled(e.target.checked)}
+                  />
+                  <span>Enable Ollama</span>
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <span className="muted">Endpoint</span>
+                  <input
+                    type="text"
+                    className="input"
+                    value={ollamaEndpoint}
+                    onChange={(e) => setOllamaEndpoint(e.target.value)}
+                  />
+                </label>
+                {ollamaEnabled ? (
+                  <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <span className="muted">Model</span>
+                    <select className="input" value={ollamaModel} onChange={(e) => setOllamaModel(e.target.value)}>
+                      <option value="">Select model</option>
+                      {models.map((m) => (
+                        <option key={m} value={m}>
+                          {m}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/apps/web/app/s/[surah]/reader-client.tsx
+++ b/apps/web/app/s/[surah]/reader-client.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react'
-import { Menu, Book, BookMarked, Settings, ChevronDown, FileText, Share2, ChevronLeft, ChevronRight, Pause, Play, ListEnd, Bookmark } from 'lucide-react'
+import { Menu, Book, BookMarked, Settings, ChevronDown, FileText, Share2, ChevronLeft, ChevronRight, Pause, Play, ListEnd, Bookmark, LoaderCircle } from 'lucide-react'
 import type { Route } from 'next'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useLocalStorage } from '../../../hooks/use-local-storage'
 import { isRtlLanguage } from '../../../lib/is-rtl-language'
 import { encodeSharePayload, decodeSharePayload } from '../../../lib/share'
+import { OllamaClient } from '../../../lib/ollama'
 import Sidebar from './Sidebar'
 import type { TranslationMeta } from '@openquranreader/types'
 import type { BookmarksSet, NotesMap, VerseKey } from './types'
@@ -54,6 +55,11 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
     const [reciter, setReciter] = useLocalStorage<string>('oqr:reciter', 'Alafasy_128kbps')
     const [autoplay, setAutoplay] = useLocalStorage<boolean>('oqr:autoplay', true)
     const [showNotes, setShowNotes] = useLocalStorage<boolean>('oqr:showNotes', true)
+    const [ollamaEnabled, setOllamaEnabled] = useLocalStorage<boolean>('oqr:ollamaEnabled', false)
+    const [ollamaEndpoint, setOllamaEndpoint] = useLocalStorage<string>('oqr:ollamaEndpoint', 'http://localhost:11434')
+    const [ollamaModel, setOllamaModel] = useLocalStorage<string>('oqr:ollamaModel', '')
+    const ollamaClient = useMemo(() => new OllamaClient(ollamaEndpoint), [ollamaEndpoint])
+    const [rootPanel, setRootPanel] = useState<{ x: number; y: number; text: string; loading: boolean } | null>(null)
     const [playingAyah, setPlayingAyah] = useState<number | null>(null)
     const audioRef = useRef<HTMLAudioElement | null>(null) as MutableRefObject<HTMLAudioElement | null>
 
@@ -170,6 +176,19 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
             else delete next[key]
             return next
         })
+    }
+
+    async function handleWordContext(e: React.MouseEvent<HTMLSpanElement>, word: string) {
+        if (!ollamaEnabled || !ollamaModel) return
+        e.preventDefault()
+        const { clientX: x, clientY: y } = e
+        setRootPanel({ x, y, text: '', loading: true })
+        const root = await ollamaClient.getRoot(word, ollamaModel)
+        setRootPanel({ x, y, text: root || 'N/A', loading: false })
+    }
+
+    function handleWordLeave() {
+        setRootPanel(null)
     }
 
     // Share helpers (URL-safe base64)
@@ -718,7 +737,9 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
                             ref={listRef}
                             style={{ '--arabic-size': arabicSizeVar, '--translation-size': translationSizeVar } as React.CSSProperties}
                         >
-                            {verses.map((v) => (
+                            {verses.map((v) => {
+                                const words = v.text_ar_simple.split(' ')
+                                return (
                                 <article
                                     key={v.ayah}
                                     id={`ayah-${v.ayah}`}
@@ -782,7 +803,17 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
                                     ) : null}
                                     <div className="arabic" dir="rtl" lang="ar">
                                         <span className="ayah-num">{v.ayah}</span>
-                                        <span>{v.text_ar_simple}</span>
+                                        {words.map((w, i) => (
+                                            <span
+                                                key={i}
+                                                onContextMenu={(e) => handleWordContext(e, w)}
+                                                onMouseLeave={handleWordLeave}
+                                                style={{ cursor: ollamaEnabled ? 'context-menu' : undefined }}
+                                            >
+                                                {w}
+                                                {i < words.length - 1 ? ' ' : ''}
+                                            </span>
+                                        ))}
                                     </div>
                                     {v.translations?.length ? (
                                         <div style={{ display: 'grid', gap: 6 }}>
@@ -853,7 +884,7 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
                                         </div>
                                     ) : null)}
                                 </article>
-                            ))}
+                                )})}
                         </div>
                     )}
                 </section>
@@ -892,6 +923,19 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
                     </button>
                 </div>
 
+                {rootPanel ? (
+                    <div
+                        className="card"
+                        style={{ position: 'fixed', top: rootPanel.y + 4, left: rootPanel.x + 4, zIndex: 50, pointerEvents: 'none' }}
+                    >
+                        {rootPanel.loading ? (
+                            <LoaderCircle className="icon spin" strokeWidth={2} aria-hidden />
+                        ) : (
+                            rootPanel.text
+                        )}
+                    </div>
+                ) : null}
+
                 <Sidebar
                     isOpen={isSidebarOpen}
                     onClose={() => setSidebarOpen(false)}
@@ -909,6 +953,12 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
                     notes={notes}
                     setBookmarks={setBookmarks}
                     setNotes={setNotes}
+                    ollamaEnabled={ollamaEnabled}
+                    setOllamaEnabled={setOllamaEnabled}
+                    ollamaEndpoint={ollamaEndpoint}
+                    setOllamaEndpoint={setOllamaEndpoint}
+                    ollamaModel={ollamaModel}
+                    setOllamaModel={setOllamaModel}
                     setActiveAyah={setActiveAyah}
                     setOpenNoteAyah={setOpenNoteAyah}
                     hydrated={hydrated}

--- a/apps/web/lib/ollama.ts
+++ b/apps/web/lib/ollama.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { Ollama } from 'ollama/browser'
+
+export class OllamaClient {
+  private client: Ollama
+
+  constructor(host: string) {
+    this.client = new Ollama({ host })
+  }
+
+  async listModels(): Promise<string[]> {
+    try {
+      const res = await this.client.list()
+      return res.models?.map((m: any) => m.name) ?? []
+    } catch {
+      return []
+    }
+  }
+
+  async getRoot(word: string, model: string): Promise<string> {
+    try {
+      const res = await this.client.generate({
+        model,
+        prompt: `You are a concise morphological analyzer. Determine the three-letter Arabic root of the word "${word}". Reply with only the root letters in Arabic, separated by spaces, and no other text. Do not explain your reasoning.`,
+        stream: false,
+      })
+      let answer = (res.response || '').trim()
+      answer = answer.replace(/<think>[\s\S]*?<\/think>/i, '').trim()
+      return answer
+    } catch {
+      return ''
+    }
+  }
+}

--- a/apps/web/ollama-browser.d.ts
+++ b/apps/web/ollama-browser.d.ts
@@ -1,0 +1,7 @@
+declare module 'ollama/browser' {
+  export class Ollama {
+    constructor(init: { host?: string })
+    list(): Promise<any>
+    generate(options: any): Promise<any>
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "lucide-react": "^0.540.0",
     "next": "14.2.7",
+    "ollama": "^0.5.17",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,6 +21,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       next:
         specifier: 14.2.7
         version: 14.2.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ollama:
+        specifier: ^0.5.17
+        version: 0.5.17
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -514,6 +517,9 @@ packages:
       sass:
         optional: true
 
+  ollama@0.5.17:
+    resolution: {integrity: sha512-q5LmPtk6GLFouS+3aURIVl+qcAOPC4+Msmx7uBb3pd+fxI55WnGjmLZ0yijI/CYy79x0QPGx3BwC3u5zv9fBvQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -659,6 +665,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1123,6 +1132,10 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  ollama@0.5.17:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -1236,6 +1249,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  whatwg-fetch@3.6.20: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- default to the first available local Ollama model when none is chosen
- trim `<think>` reasoning blocks and enhance prompt for faster root extraction
- show a rotating loader while waiting for Ollama responses

## Testing
- `pnpm lint` (fails: ESLint couldn't find config)
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a987513eb48332899695ba6a684c73