### PR TITLE
Cancel Ollama requests when root panel closes

### DIFF
--- a/apps/web/app/s/[surah]/reader-client.tsx
+++ b/apps/web/app/s/[surah]/reader-client.tsx
@@ -60,6 +60,7 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
     const [ollamaModel, setOllamaModel] = useLocalStorage<string>('oqr:ollamaModel', '')
     const ollamaClient = useMemo(() => new OllamaClient(ollamaEndpoint), [ollamaEndpoint])
     const [rootPanel, setRootPanel] = useState<{ x: number; y: number; text: string; loading: boolean } | null>(null)
+    const rootAbortRef = useRef<AbortController | null>(null)
     const [playingAyah, setPlayingAyah] = useState<number | null>(null)
     const audioRef = useRef<HTMLAudioElement | null>(null) as MutableRefObject<HTMLAudioElement | null>
 
@@ -182,12 +183,21 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
         if (!ollamaEnabled || !ollamaModel) return
         e.preventDefault()
         const { clientX: x, clientY: y } = e
+        rootAbortRef.current?.abort()
+        const controller = new AbortController()
+        rootAbortRef.current = controller
         setRootPanel({ x, y, text: '', loading: true })
-        const root = await ollamaClient.getRoot(word, ollamaModel)
-        setRootPanel({ x, y, text: root || 'N/A', loading: false })
+        try {
+            const root = await ollamaClient.getRoot(word, ollamaModel, controller.signal)
+            if (!controller.signal.aborted) setRootPanel({ x, y, text: root || 'N/A', loading: false })
+        } catch {
+            if (!controller.signal.aborted) setRootPanel({ x, y, text: 'N/A', loading: false })
+        }
     }
 
     function handleWordLeave() {
+        rootAbortRef.current?.abort()
+        rootAbortRef.current = null
         setRootPanel(null)
     }
 

--- a/apps/web/lib/ollama.ts
+++ b/apps/web/lib/ollama.ts
@@ -4,9 +4,11 @@ import { Ollama } from 'ollama/browser'
 
 export class OllamaClient {
   private client: Ollama
+  private host: string
 
   constructor(host: string) {
     this.client = new Ollama({ host })
+    this.host = host
   }
 
   async listModels(): Promise<string[]> {
@@ -14,14 +16,20 @@ export class OllamaClient {
     return res.models?.map((m: any) => m.name) ?? []
   }
 
-  async getRoot(word: string, model: string): Promise<string> {
+  async getRoot(word: string, model: string, signal?: AbortSignal): Promise<string> {
     try {
-      const res = await this.client.generate({
-        model,
-        prompt: `You are a concise morphological analyzer. Determine the three-letter Arabic root of the word "${word}". Reply with only the root letters in Arabic, separated by spaces, and no other text. Do not explain your reasoning.`,
-        stream: false,
+      const res = await fetch(`${this.host}/api/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          prompt: `You are a concise morphological analyzer. Determine the three-letter Arabic root of the word "${word}". Reply with only the root letters in Arabic, separated by spaces, and no other text. Do not explain your reasoning.`,
+          stream: false,
+        }),
+        signal,
       })
-      let answer = (res.response || '').trim()
+      const data = await res.json()
+      let answer = (data.response || '').trim()
       answer = answer.replace(/<think>[\s\S]*?<\/think>/i, '').trim()
       return answer
     } catch {


### PR DESCRIPTION
## Summary
- add abortable fetch for root lookup
- cancel pending Ollama requests when root panel closes

## Testing
- `pnpm --filter web lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm --filter web typecheck` *(fails: sp is possibly null in reader-client.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c99899cc83328952458145f33dfc