### PR TITLE
feat: provide verse context for root lookup

### DIFF
--- a/apps/web/app/s/[surah]/reader-client.tsx
+++ b/apps/web/app/s/[surah]/reader-client.tsx
@@ -179,7 +179,7 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
         })
     }
 
-    async function handleWordContext(e: React.MouseEvent<HTMLSpanElement>, word: string) {
+    async function handleWordContext(e: React.MouseEvent<HTMLSpanElement>, word: string, verse: string) {
         if (!ollamaEnabled || !ollamaModel) return
         e.preventDefault()
         const { clientX: x, clientY: y } = e
@@ -188,7 +188,7 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
         rootAbortRef.current = controller
         setRootPanel({ x, y, text: '', loading: true })
         try {
-            const root = await ollamaClient.getRoot(word, ollamaModel, controller.signal)
+            const root = await ollamaClient.getRoot(word, verse, ollamaModel, controller.signal)
             if (!controller.signal.aborted) setRootPanel({ x, y, text: root || 'N/A', loading: false })
         } catch {
             if (!controller.signal.aborted) setRootPanel({ x, y, text: 'N/A', loading: false })
@@ -816,7 +816,7 @@ export default function ReaderClient({ params }: { params: { surah: string } }) 
                                         {words.map((w, i) => (
                                             <span
                                                 key={i}
-                                                onContextMenu={(e) => handleWordContext(e, w)}
+                                                onContextMenu={(e) => handleWordContext(e, w, v.text_ar_simple)}
                                                 onMouseLeave={handleWordLeave}
                                                 style={{ cursor: ollamaEnabled ? 'context-menu' : undefined }}
                                             >

--- a/apps/web/lib/ollama.ts
+++ b/apps/web/lib/ollama.ts
@@ -16,14 +16,14 @@ export class OllamaClient {
     return res.models?.map((m: any) => m.name) ?? []
   }
 
-  async getRoot(word: string, model: string, signal?: AbortSignal): Promise<string> {
+  async getRoot(word: string, verse: string, model: string, signal?: AbortSignal): Promise<string> {
     try {
       const res = await fetch(`${this.host}/api/generate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           model,
-          prompt: `You are a concise morphological analyzer. Determine the three-letter Arabic root of the word "${word}". Reply with only the root letters in Arabic, separated by spaces, and no other text. Do not explain your reasoning.`,
+          prompt: `You are a concise morphological analyzer. Given the Quranic verse "${verse}", determine the three-letter Arabic root of the word "${word}" in that verse. Reply with only the root letters in Arabic, separated by spaces, and no other text. Do not explain your reasoning.`,
           stream: false,
         }),
         signal,


### PR DESCRIPTION
## Summary
- send full verse along with word to Ollama when requesting three-letter root
- thread verse into reader word-context handler

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config file)*
- `pnpm typecheck` *(fails: "sp" is possibly null in reader-client.tsx)*
- `pnpm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cce760ac833280f1b7c9c2e15a15