### PR TITLE
fix: apply base path for beta builds

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -18,7 +18,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter web run prebuild
-      - run: NEXT_PUBLIC_BASE_PATH=/quran_reader/beta pnpm --filter web build
+      - run: pnpm --filter web build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /quran_reader/beta
+          BASE_PATH: /quran_reader/beta
       - name: Deploy to gh-pages/beta
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter web run prebuild
-      - run: NEXT_PUBLIC_BASE_PATH=/quran_reader pnpm --filter web build
+      - run: pnpm --filter web build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /quran_reader
+          BASE_PATH: /quran_reader
       - name: Deploy to gh-pages root
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,3 +1,5 @@
+const basePath = process.env.BASE_PATH || process.env.NEXT_PUBLIC_BASE_PATH || ''
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -6,8 +8,8 @@ const nextConfig = {
     typedRoutes: true,
   },
   // For GitHub Pages under a subpath, set at build time:
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || undefined,
-  assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH ? `${process.env.NEXT_PUBLIC_BASE_PATH}/` : undefined,
+  basePath: basePath || undefined,
+  assetPrefix: basePath || undefined,
   trailingSlash: true,
 }
 


### PR DESCRIPTION
## Summary
- read deployment base path from BASE_PATH or NEXT_PUBLIC_BASE_PATH
- pass base path env vars in beta and prod deployment workflows

## Testing
- `pnpm -r lint`
- `pnpm -r typecheck`
- `pnpm -r test --if-present`
- `BASE_PATH=/quran_reader NEXT_PUBLIC_BASE_PATH=/quran_reader pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68ab386402c083329d6ecdb7cdb7ffc0