### PR TITLE
Fix beta deployment path

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -22,12 +22,12 @@ jobs:
         env:
           NEXT_PUBLIC_BASE_PATH: /quran_reader/beta
           BASE_PATH: /quran_reader/beta
-      - name: Deploy to gh-pages/beta
+      - name: Deploy to gh-pages/quran_reader/beta
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: apps/web/out
-          destination_dir: beta
+          destination_dir: quran_reader/beta
           keep_files: true
           commit_message: "Deploy beta: ${{ github.sha }}"


### PR DESCRIPTION
## Summary
- deploy beta builds to `gh-pages/quran_reader/beta`

## Testing
- `pnpm -r lint`
- `pnpm -r typecheck`
- `pnpm -r test --if-present`
- `NEXT_PUBLIC_BASE_PATH=/quran_reader BASE_PATH=/quran_reader pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68ab55a4b2f08332a25ebec69bd016e6