### PR TITLE
Fix beta deployment path

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -20,8 +20,8 @@ jobs:
       - run: pnpm --filter web run prebuild
       - run: pnpm --filter web build
         env:
-          NEXT_PUBLIC_BASE_PATH: /quran_reader/beta
-          BASE_PATH: /quran_reader/beta
+          NEXT_PUBLIC_BASE_PATH: /beta
+          BASE_PATH: /beta
       - name: Deploy to gh-pages/beta
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- ensure beta builds use `/beta` base path and publish to `gh-pages/beta`

## Testing
- `pnpm -r lint`
- `pnpm -r typecheck`
- `pnpm -r test --if-present`
- `NEXT_PUBLIC_BASE_PATH=/quran_reader BASE_PATH=/quran_reader pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68ab55a4b2f08332a25ebec69bd016e6