### PR TITLE
fix: correct beta deployment path

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -20,14 +20,14 @@ jobs:
       - run: pnpm --filter web run prebuild
       - run: pnpm --filter web build
         env:
-          NEXT_PUBLIC_BASE_PATH: /beta
-          BASE_PATH: /beta
+          NEXT_PUBLIC_BASE_PATH: /quran_reader/beta
+          BASE_PATH: /quran_reader/beta
       - name: Deploy to gh-pages/beta
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: apps/web/out
-          destination_dir: beta
+          destination_dir: quran_reader/beta
           keep_files: true
           commit_message: "Deploy beta: ${{ github.sha }}"


### PR DESCRIPTION
## Summary
- ensure beta deployment uses `/quran_reader/beta` base path

## Testing
- `pnpm -r lint`
- `pnpm -r typecheck`
- `pnpm -r test --if-present`
- `NEXT_PUBLIC_BASE_PATH=/quran_reader pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68ab77029df4833281ce2334026f82e0