### PR TITLE
fix beta deployment base path

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -20,8 +20,8 @@ jobs:
       - run: pnpm --filter web run prebuild
       - run: pnpm --filter web build
         env:
-          NEXT_PUBLIC_BASE_PATH: /quran_reader/beta
-          BASE_PATH: /quran_reader/beta
+          NEXT_PUBLIC_BASE_PATH: /beta
+          BASE_PATH: /beta
       - name: Deploy to gh-pages/beta
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- adjust beta workflow to build with `/beta` base path so that exported site works under `/quran_reader/beta`

## Testing
- `pnpm -r lint`
- `pnpm -r typecheck`
- `pnpm -r test --if-present`
- `NEXT_PUBLIC_BASE_PATH=/quran_reader pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68ab78ffef5c8332aece13962d8d6111