### PR TITLE
chore: update beta deploy workflow

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -30,28 +30,12 @@ jobs:
             echo "ERROR: apps/web/out/index.html is missing" >&2
             exit 1
           fi
-      - name: Cleanup legacy quran_reader/beta path
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages-work
-      - name: Remove legacy folder and push
-        run: |
-          cd gh-pages-work
-          if [ -d quran_reader ]; then
-            rm -rf quran_reader
-            git add -A
-            git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" commit -m "Cleanup legacy quran_reader folder"
-            git push origin gh-pages
-          else
-            echo "No legacy folder to remove"
-          fi
       - name: Deploy to gh-pages/beta
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: apps/web/out
-          destination_dir: beta
-          keep_files: false
+          destination_dir: quran_reader/beta
+          keep_files: true
           commit_message: "Deploy beta: ${{ github.sha }}"


### PR DESCRIPTION
## Summary
- simplify beta deployment workflow by removing legacy cleanup steps
- deploy beta build to `quran_reader/beta` while keeping existing files

## Testing
- `pnpm -r lint`
- `pnpm -r typecheck`
- `pnpm -r test --if-present`
- `NEXT_PUBLIC_BASE_PATH=/quran_reader pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1ef39c788332ac32471c2f860e03